### PR TITLE
Add basic support for grabbing event data from Club Hub

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,8 @@ def special(incoming):
         body = laundry.special
     elif incoming.upper() == "WEATHER":
         body = weather.special
+    elif incoming.upper() == "EVENTS":
+        body = events.eval(None)
     elif incoming.upper() == "DEMO":
         ## welcome/instructions
         body = 'Thanks for using Harvard Now!\n'
@@ -45,6 +47,7 @@ def special(incoming):
         body += 'Sending part of a name gives all information associated with that name.\n'
         body += 'For example sending Quad will give information about the shuttle stop Quad and the shuttle'
         body += 'route Quad Yard Express and sending Quincy laundry will give all the laundry rooms in Quincy.\n'
+        body += 'For a list of events in the next 24 hours, send events\n\n'
     return body
 
 ## main function

--- a/services/events/events.py
+++ b/services/events/events.py
@@ -11,7 +11,6 @@ def getEvents():
     events = []
     url = 'https://h.clubhub.live/'
 
-    print(url)
     website = urllib2.urlopen(urllib2.Request(
         url,
         headers={'User-Agent': 'Mozilla/5.0'}

--- a/services/events/events.py
+++ b/services/events/events.py
@@ -1,0 +1,54 @@
+import urllib2
+import datetime
+from bs4 import BeautifulSoup
+
+
+#####################################
+##    Club Hub Events Function     ##
+#####################################
+
+def getEvents():
+    events = []
+    url = 'https://h.clubhub.live/'
+
+    print(url)
+    website = urllib2.urlopen(urllib2.Request(
+        url,
+        headers={'User-Agent': 'Mozilla/5.0'}
+    ))
+    soup = BeautifulSoup(website.read(), 'html.parser')
+    event_divs = soup.select(".event")
+
+    for event_div in event_divs:
+        if not event_div:
+            continue
+        event = {
+            'name': event_div['data-name'],
+            'host': event_div['data-host'],
+            'starts': int(event_div['data-start'])
+        }
+
+        now = int(datetime.datetime.now().strftime("%s"))
+        if event['starts'] > now + 24 * 60 * 60:
+            continue
+
+        events.append(event)
+
+    return events
+
+
+############################
+##       Top-Level        ##
+############################
+
+def eval(cmd):
+    events = getEvents()
+    return "Events in the next 24 hours:\n" + \
+           "\n".join([
+               "{}: {} ({})".format(
+                   datetime.datetime.fromtimestamp(event['starts']).strftime("%a %-I:%M%p"),
+                   event['name'],
+                   event['host']
+               )
+               for event in events]) + "\n" + \
+           "(Read more on Club Hub: https://h.clubhub.live)\n\n"


### PR DESCRIPTION
[Club Hub](https://h.clubhub.live) is a project I am working on to catalog campus event data. This code addition adds basic support for grabbing information from Club Hub so that HarvardNow can return a summary of events in the next 24 hours.

I'm not sure if I used the "special" endpoint correctly. The datagrab from Club Hub does not take any arguments, so I thought I would put it there. However, if that's not the right place to put it, let me know and I'll fix it and submit another pull request.

This work was done for HCS Bootcamp 4.